### PR TITLE
Tilltak for å få til litt raskere innlesing og generering av påløpsfil.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <name>bidrag-regnskap</name>
   <properties>
     <java.version>21</java.version>
-    <kotlin.version>1.9.20</kotlin.version>
+    <kotlin.version>1.9.21</kotlin.version>
     <kotlin-coroutines.version>1.7.3</kotlin-coroutines.version>
     <bidrag-commons.version>20231114143627_14d61cd</bidrag-commons.version>
     <bidrag-transport.version>20231113102624_1040a39</bidrag-transport.version>
@@ -26,12 +26,12 @@
     <mockk.version>1.13.5</mockk.version>
     <kotest.version>5.6.2</kotest.version>
     <bidrag-commons-test.version>1.20230511093912_dc35d81</bidrag-commons-test.version>
-    <shedlock.version>5.10.0</shedlock.version>
+    <shedlock.version>5.10.2</shedlock.version>
     <google-api-extention.version>2.37.0</google-api-extention.version>
     <google-cloud-storage.version>2.22.2</google-cloud-storage.version>
     <jsch.version>0.2.8</jsch.version>
     <testcontainers.version>1.19.3</testcontainers.version>
-    <maven-failsafe-plugin.version>3.1.0</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
     <spring-kafka.version>3.0.12</spring-kafka.version>
     <scala.version>2.13.12</scala.version>
     <kotlin-logging-jwv.version>5.1.0</kotlin-logging-jwv.version>

--- a/src/main/kotlin/no/nav/bidrag/regnskap/persistence/repository/OppdragRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/regnskap/persistence/repository/OppdragRepository.kt
@@ -2,9 +2,21 @@ package no.nav.bidrag.regnskap.persistence.repository
 
 import no.nav.bidrag.regnskap.persistence.entity.Oppdrag
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface OppdragRepository : JpaRepository<Oppdrag, Int> {
-    fun findByStønadTypeAndKravhaverIdentAndSkyldnerIdentAndSakId(
+
+    @Query(
+        """ SELECT o
+            FROM oppdrag o
+            JOIN FETCH o.oppdragsperioder
+            WHERE o.stønadType = :stønadType 
+                AND o.kravhaverIdent = :kravhaverIdent 
+                AND o.skyldnerIdent = :skyldnerIdent 
+                AND o.sakId = :sakId
+        """,
+    )
+    fun finnOppdragMedStønadTypeKravhanderSkylderOgSaksnummer(
         stønadType: String,
         kravhaverIdent: String?,
         skyldnerIdent: String,

--- a/src/main/kotlin/no/nav/bidrag/regnskap/persistence/repository/OppdragsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/regnskap/persistence/repository/OppdragsperiodeRepository.kt
@@ -11,8 +11,8 @@ interface OppdragsperiodeRepository : JpaRepository<Oppdragsperiode, Int> {
         """
           SELECT o.oppdragsperiodeId
             FROM oppdragsperioder o
-            WHERE konteringerFullførtOpprettet = false
-              AND opphørendeOppdragsperiode = false""",
+            WHERE o.konteringerFullførtOpprettet = false
+              AND o.opphørendeOppdragsperiode = false""",
     )
     @Transactional
     fun hentAlleOppdragsperioderSomIkkeHarOpprettetAlleKonteringer(): List<Int>
@@ -26,7 +26,14 @@ interface OppdragsperiodeRepository : JpaRepository<Oppdragsperiode, Int> {
     )
     fun hentAlleOppdragsperioderForListe(oppdragsperioder: List<Int>): List<Oppdragsperiode>
 
-    fun findByReferanseAndVedtakId(referanse: String, vedtakId: Int): List<Oppdragsperiode>
+    @Query(
+        """ SELECT o
+            FROM oppdragsperioder o
+            JOIN FETCH o.oppdrag
+            WHERE o.referanse = :referanse AND o.vedtakId = :vedtakId
+        """,
+    )
+    fun hentOppdragPåReferanseOgVedtakId(referanse: String, vedtakId: Int): List<Oppdragsperiode>
 
     fun findAllByMottakerIdent(mottakerIdent: String): List<Oppdragsperiode>
 }

--- a/src/main/kotlin/no/nav/bidrag/regnskap/service/OppdragService.kt
+++ b/src/main/kotlin/no/nav/bidrag/regnskap/service/OppdragService.kt
@@ -59,7 +59,7 @@ class OppdragService(
         oppdatererVerdierPåOppdrag(hendelse, oppdrag)
         val oppdragId = persistenceService.lagreOppdrag(oppdrag)
 
-        LOGGER.info("Oppdrag med ID: $oppdragId er ${if (erOppdatering) "oppdatert." else "opprettet."}")
+        LOGGER.debug("Oppdrag med ID: $oppdragId er ${if (erOppdatering) "oppdatert." else "opprettet."}")
 
         return oppdragId
     }
@@ -79,7 +79,7 @@ class OppdragService(
     }
 
     private fun opprettOppdrag(hendelse: Hendelse): Oppdrag {
-        LOGGER.info("Fant ikke eksisterende oppdrag for vedtakID: ${hendelse.vedtakId}. Opprettet nytt oppdrag..")
+        LOGGER.debug("Fant ikke eksisterende oppdrag for vedtakID: ${hendelse.vedtakId}. Opprettet nytt oppdrag..")
         return Oppdrag(
             stønadType = hendelse.type,
             sakId = hendelse.sakId,

--- a/src/main/kotlin/no/nav/bidrag/regnskap/service/PersistenceService.kt
+++ b/src/main/kotlin/no/nav/bidrag/regnskap/service/PersistenceService.kt
@@ -45,10 +45,10 @@ class PersistenceService(
     }
 
     fun hentOppdragPaUnikeIdentifikatorer(stønadType: String, kravhaverIdent: String?, skyldnerIdent: String, sakId: String): Oppdrag? {
-        SECURE_LOGGER.info(
+        SECURE_LOGGER.debug(
             "Henter oppdrag med stønadType: $stønadType, kravhaverIdent: $kravhaverIdent, skyldnerIdent: $skyldnerIdent, sakId: $sakId",
         )
-        return oppdragRepository.findByStønadTypeAndKravhaverIdentAndSkyldnerIdentAndSakId(
+        return oppdragRepository.finnOppdragMedStønadTypeKravhanderSkylderOgSaksnummer(
             stønadType,
             kravhaverIdent,
             skyldnerIdent,
@@ -58,7 +58,7 @@ class PersistenceService(
 
     fun hentOppdragPåReferanseOgOmgjørVedtakId(referanse: String, omgjørVedtakId: Int): Oppdrag? {
         LOGGER.debug("Henter oppdrag på referanse: $referanse og omgjørVedtakId: $omgjørVedtakId")
-        return oppdragsperiodeRepository.findByReferanseAndVedtakId(referanse, omgjørVedtakId).firstOrNull()?.oppdrag
+        return oppdragsperiodeRepository.hentOppdragPåReferanseOgVedtakId(referanse, omgjørVedtakId).firstOrNull()?.oppdrag
     }
 
     fun lagreOppdrag(oppdrag: Oppdrag): Int {
@@ -94,6 +94,7 @@ class PersistenceService(
         return påløpRepository.findAllByFullførtTidspunktIsNull()
     }
 
+    @Cacheable(value = ["siste_overforte_periode_cache"])
     fun finnSisteOverførtePeriode(): YearMonth {
         LOGGER.debug("Henter siste overførte periode.")
         try {

--- a/src/test/kotlin/no/nav/bidrag/regnskap/fil/påløp/PåløpsfilGeneratorIT.kt
+++ b/src/test/kotlin/no/nav/bidrag/regnskap/fil/påløp/PåløpsfilGeneratorIT.kt
@@ -63,7 +63,6 @@ class PåløpsfilGeneratorIT {
         }
     }
 
-
     @Autowired
     private lateinit var persistenceService: PersistenceService
 
@@ -77,6 +76,7 @@ class PåløpsfilGeneratorIT {
         påløpsfilGenerator = PåløpsfilGenerator(gcpFilBucket, filoverføringTilElinKlient, persistenceService)
         opprettOppdragOgOppdragsperioderOgKonteringer(antallOppdrag)
     }
+
     @Test
     fun `skal ta tiden på opprettelse av filgenerering`() {
         val tidsbruk = measureTime {
@@ -118,7 +118,7 @@ class PåløpsfilGeneratorIT {
                 behandlingsstatusOkTidspunkt = null,
                 type = Type.NY.name,
                 søknadType = Søknadstype.EN.name,
-                vedtakId = Random.nextInt()
+                vedtakId = Random.nextInt(),
             )
             val kontering2 = Kontering(
                 oppdragsperiode = oppdragsperiode,
@@ -128,7 +128,7 @@ class PåløpsfilGeneratorIT {
                 behandlingsstatusOkTidspunkt = null,
                 type = Type.NY.name,
                 søknadType = Søknadstype.EN.name,
-                vedtakId = Random.nextInt()
+                vedtakId = Random.nextInt(),
             )
             oppdragsperiode.konteringer = listOf(kontering, kontering2)
             oppdrag.oppdragsperioder = listOf(oppdragsperiode)

--- a/src/test/kotlin/no/nav/bidrag/regnskap/fil/påløp/PåløpsfilGeneratorIT.kt
+++ b/src/test/kotlin/no/nav/bidrag/regnskap/fil/påløp/PåløpsfilGeneratorIT.kt
@@ -1,0 +1,139 @@
+package no.nav.bidrag.regnskap.fil.påløp
+
+import io.mockk.mockk
+import no.nav.bidrag.commons.util.PersonidentGenerator
+import no.nav.bidrag.domene.enums.regnskap.Søknadstype
+import no.nav.bidrag.domene.enums.regnskap.Transaksjonskode
+import no.nav.bidrag.domene.enums.regnskap.Type
+import no.nav.bidrag.regnskap.BidragRegnskapLocal
+import no.nav.bidrag.regnskap.fil.overføring.FiloverføringTilElinKlient
+import no.nav.bidrag.regnskap.persistence.bucket.GcpFilBucket
+import no.nav.bidrag.regnskap.persistence.entity.Kontering
+import no.nav.bidrag.regnskap.persistence.entity.Oppdrag
+import no.nav.bidrag.regnskap.persistence.entity.Oppdragsperiode
+import no.nav.bidrag.regnskap.persistence.entity.Påløp
+import no.nav.bidrag.regnskap.service.PersistenceService
+import no.nav.bidrag.regnskap.service.PåløpskjøringServiceIT
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.random.Random
+import kotlin.time.measureTime
+
+@Disabled("Denne er for å teste hastighet ved påløpsfilgenerering. Bør ikke kjøres fast.")
+@Transactional
+@ActiveProfiles("test")
+@EnableMockOAuth2Server
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = [BidragRegnskapLocal::class])
+@EmbeddedKafka(partitions = 1, brokerProperties = ["listeners=PLAINTEXT://localhost:9092", "port=9092"])
+class PåløpsfilGeneratorIT {
+
+    companion object {
+
+        val antallOppdrag = 2000
+
+        private var postgreSqlDb = PostgreSQLContainer("postgres:latest").apply {
+            withDatabaseName("bidrag-regnskap")
+            withUsername("cloudsqliamuser")
+            withPassword("admin")
+            withEnv("reWriteBatchedInserts", "true")
+            start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgreSqlDb::getJdbcUrl)
+            registry.add("spring.datasource.username", postgreSqlDb::getUsername)
+            registry.add("spring.datasource.password", postgreSqlDb::getPassword)
+        }
+    }
+
+
+    @Autowired
+    private lateinit var persistenceService: PersistenceService
+
+    private val gcpFilBucket: GcpFilBucket = mockk<GcpFilBucket>(relaxed = true)
+    private val filoverføringTilElinKlient: FiloverføringTilElinKlient = mockk<FiloverføringTilElinKlient>(relaxed = true)
+
+    private lateinit var påløpsfilGenerator: PåløpsfilGenerator
+
+    @BeforeAll
+    fun beforeAll() {
+        påløpsfilGenerator = PåløpsfilGenerator(gcpFilBucket, filoverføringTilElinKlient, persistenceService)
+        opprettOppdragOgOppdragsperioderOgKonteringer(antallOppdrag)
+    }
+    @Test
+    fun `skal ta tiden på opprettelse av filgenerering`() {
+        val tidsbruk = measureTime {
+            påløpsfilGenerator.skrivPåløpsfilOgLastOppPåFilsluse(Påløp(kjøredato = LocalDateTime.now(), forPeriode = "2023-01"), emptyList())
+        }
+
+        val tidsbrukISekunder = tidsbruk.inWholeMilliseconds.toDouble() / 1000
+        println("Det tok $tidsbrukISekunder sekunder å opprette ${PåløpskjøringServiceIT.antallOppdrag} oppdrag.")
+    }
+
+    @Suppress("SameParameterValue")
+    private fun opprettOppdragOgOppdragsperioderOgKonteringer(antallOppdrag: Int) {
+        for (i in 0..<antallOppdrag) {
+            val oppdrag = Oppdrag(
+                stønadType = "BIDRAG",
+                sakId = Random.nextInt().toString(),
+                skyldnerIdent = PersonidentGenerator.genererFødselsnummer(),
+                gjelderIdent = PersonidentGenerator.genererFødselsnummer(),
+            )
+            val oppdragsperiode = Oppdragsperiode(
+                oppdrag = oppdrag,
+                vedtakId = Random.nextInt(),
+                vedtakType = "FASTSETTELSE",
+                mottakerIdent = PersonidentGenerator.genererFødselsnummer(),
+                beløp = BigDecimal(Random.nextDouble()),
+                valuta = "NOK",
+                periodeFra = LocalDate.of(2023, 1, 1),
+                vedtaksdato = LocalDate.now(),
+                opprettetAv = "TEST",
+                periodeTil = null,
+                delytelseId = null,
+                referanse = null,
+            )
+            val kontering = Kontering(
+                oppdragsperiode = oppdragsperiode,
+                transaksjonskode = Transaksjonskode.B1.name,
+                overføringsperiode = "2023-01",
+                overføringstidspunkt = null,
+                behandlingsstatusOkTidspunkt = null,
+                type = Type.NY.name,
+                søknadType = Søknadstype.EN.name,
+                vedtakId = Random.nextInt()
+            )
+            val kontering2 = Kontering(
+                oppdragsperiode = oppdragsperiode,
+                transaksjonskode = Transaksjonskode.B1.name,
+                overføringsperiode = "2023-02",
+                overføringstidspunkt = null,
+                behandlingsstatusOkTidspunkt = null,
+                type = Type.NY.name,
+                søknadType = Søknadstype.EN.name,
+                vedtakId = Random.nextInt()
+            )
+            oppdragsperiode.konteringer = listOf(kontering, kontering2)
+            oppdrag.oppdragsperioder = listOf(oppdragsperiode)
+
+            persistenceService.oppdragRepository.save(oppdrag)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/bidrag/regnskap/service/OppdragServiceIT.kt
+++ b/src/test/kotlin/no/nav/bidrag/regnskap/service/OppdragServiceIT.kt
@@ -74,7 +74,6 @@ class OppdragServiceIT {
     @BeforeEach
     fun beforeEach() {
         sakApiWireMock.sakMedGyldigResponse()
-
     }
 
     @Test
@@ -112,9 +111,9 @@ class OppdragServiceIT {
                             periodeFomDato = LocalDate.of(2023, 1, 1),
                             periodeTilDato = null,
                             delytelsesId = null,
-                        )
-                    )
-                )
+                        ),
+                    ),
+                ),
             )
         }
         return hendelser

--- a/src/test/kotlin/no/nav/bidrag/regnskap/service/OppdragServiceIT.kt
+++ b/src/test/kotlin/no/nav/bidrag/regnskap/service/OppdragServiceIT.kt
@@ -1,0 +1,124 @@
+package no.nav.bidrag.regnskap.service
+
+import no.nav.bidrag.commons.util.PersonidentGenerator
+import no.nav.bidrag.domene.enums.Vedtakstype
+import no.nav.bidrag.regnskap.BidragRegnskapLocal
+import no.nav.bidrag.regnskap.consumer.SakApiWireMock
+import no.nav.bidrag.regnskap.dto.vedtak.Hendelse
+import no.nav.bidrag.regnskap.dto.vedtak.Periode
+import no.nav.bidrag.regnskap.persistence.entity.Påløp
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.random.Random
+import kotlin.time.measureTime
+
+@Disabled("Denne er for å teste hastighet ved opprettelse av oppdrag fra hendelser. Bør ikke kjøres fast.")
+@Transactional
+@ActiveProfiles("test")
+@EnableMockOAuth2Server
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = [BidragRegnskapLocal::class])
+@EmbeddedKafka(partitions = 1, brokerProperties = ["listeners=PLAINTEXT://localhost:9092", "port=9092"])
+class OppdragServiceIT {
+    companion object {
+
+        val antallHendelser = 600
+
+        private var sakApiWireMock: SakApiWireMock = SakApiWireMock()
+
+        private var postgreSqlDb = PostgreSQLContainer("postgres:latest").apply {
+            withDatabaseName("bidrag-regnskap")
+            withUsername("cloudsqliamuser")
+            withPassword("admin")
+            withEnv("reWriteBatchedInserts", "true")
+            start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgreSqlDb::getJdbcUrl)
+            registry.add("spring.datasource.username", postgreSqlDb::getUsername)
+            registry.add("spring.datasource.password", postgreSqlDb::getPassword)
+        }
+    }
+
+    @Autowired
+    private lateinit var oppdragService: OppdragService
+
+    @Autowired
+    private lateinit var persistenceService: PersistenceService
+
+    private var påløp: Påløp? = null
+
+    @BeforeAll
+    fun beforeAll() {
+        påløp = lagrePåløp()
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        sakApiWireMock.sakMedGyldigResponse()
+
+    }
+
+    @Test
+    fun `skal ta tiden på opprettelse av hendelser`() {
+        val tidsbruk = measureTime {
+            opprettHendelser(antallHendelser).forEach {
+                oppdragService.lagreHendelse(it)
+            }
+        }
+        val tidsbrukISekunder = tidsbruk.inWholeMilliseconds.toDouble() / 1000
+        println("Det tok $tidsbrukISekunder sekunder å opprette $antallHendelser hendelser.")
+    }
+
+    @Suppress("SameParameterValue")
+    private fun opprettHendelser(antallHendelser: Int): List<Hendelse> {
+        val hendelser: MutableList<Hendelse> = mutableListOf()
+        for (i in 0..<antallHendelser) {
+            hendelser.add(
+                Hendelse(
+                    type = "BIDRAG",
+                    vedtakType = Vedtakstype.FASTSETTELSE,
+                    kravhaverIdent = PersonidentGenerator.genererFødselsnummer(),
+                    skyldnerIdent = PersonidentGenerator.genererFødselsnummer(),
+                    mottakerIdent = PersonidentGenerator.genererFødselsnummer(),
+                    sakId = Random.nextInt().toString(),
+                    vedtakId = Random.nextInt(),
+                    vedtakDato = LocalDate.now(),
+                    opprettetAv = "TEST",
+                    utsattTilDato = null,
+                    eksternReferanse = null,
+                    periodeListe = listOf(
+                        Periode(
+                            beløp = BigDecimal.valueOf(Random.nextDouble()),
+                            valutakode = "NOK",
+                            periodeFomDato = LocalDate.of(2023, 1, 1),
+                            periodeTilDato = null,
+                            delytelsesId = null,
+                        )
+                    )
+                )
+            )
+        }
+        return hendelser
+    }
+
+    fun lagrePåløp() = persistenceService.påløpRepository.save(Påløp(kjøredato = LocalDateTime.now(), forPeriode = "2023-02"))
+}


### PR DESCRIPTION
* Cache på siste overførte periode for å unngår et databasekall for hver oppretting. Cachen er satt til 60 sekunder.
* Join fetch på henting av oppdrag med stønadstype, kravhaver, skyldner og saksnummer.
* Join fetch på henting av oppdrag på referanse og vedtakId